### PR TITLE
Adds option for str_count to allow overlapping matches

### DIFF
--- a/src/docstrings.jl
+++ b/src/docstrings.jl
@@ -1,12 +1,14 @@
 const docstring_str_detect  =
 """
-    str_detect(string::String, pattern::Union{String, Regex})
+    str_detect(string::String, pattern::Union{String, Regex}; overlap::Bool=false)
 
 Determine if a string contains a certain pattern.
 
 # Arguments
 - `string`: The string to check.
-pattern: A string or a regular expression to find within the string.
+- `pattern`: A string or a regular expression to find within the string.
+- `overlap`: Whether the pattern can overlap (default false)
+
 The pattern can include special logic:
 
 Use | to represent "or" (e.g., "red|blue" matches any string that contains "red" or "blue").

--- a/src/matching.jl
+++ b/src/matching.jl
@@ -1,7 +1,7 @@
 """
 $docstring_str_count
 """
-function str_count(column, pattern::Union{String,Regex})
+function str_count(column, pattern::Union{String,Regex}; overlap::Bool=false)
     if ismissing(column)
         return (column)
     end
@@ -11,7 +11,7 @@ function str_count(column, pattern::Union{String,Regex})
     end
 
     # Count the number of matches for the regular expression
-    return length(collect(eachmatch(pattern, column)))
+    return length(collect(eachmatch(pattern, column, overlap=overlap)))
 end
 
 """
@@ -111,7 +111,7 @@ end
 """
 $docstring_str_replace_all
 """
-function str_replace_all(column, pattern::Union{String, Regex}, replacement::String)
+function str_replace_all(column, pattern::Union{String,Regex}, replacement::String)
     if ismissing(column)
         return column
     end
@@ -119,7 +119,7 @@ function str_replace_all(column, pattern::Union{String, Regex}, replacement::Str
     regex_pattern = isa(pattern, String) ? Regex(pattern) : pattern
 
     column = replace(column, regex_pattern => replacement)
-    
+
     return replace(column, r"\s+" => " ")
 end
 
@@ -191,7 +191,7 @@ end
 """
 $docstring_str_starts
 """
-function str_starts(string::AbstractString, pattern::Union{AbstractString, Regex}; negate::Bool=false)::Bool
+function str_starts(string::AbstractString, pattern::Union{AbstractString,Regex}; negate::Bool=false)::Bool
     if ismissing(string)
         return (string)
     end
@@ -202,13 +202,13 @@ function str_starts(string::AbstractString, pattern::Union{AbstractString, Regex
     else
         error("Pattern must be either a Regex or an AbstractString.")
     end
-    
+
     return negate ? !match_result : match_result
 end
 """
 $docstring_str_ends
 """
-function str_ends(string::AbstractString, pattern::Union{AbstractString, Regex}; negate::Bool=false)::Bool
+function str_ends(string::AbstractString, pattern::Union{AbstractString,Regex}; negate::Bool=false)::Bool
     if ismissing(string)
         return (string)
     end
@@ -219,7 +219,7 @@ function str_ends(string::AbstractString, pattern::Union{AbstractString, Regex};
     else
         error("Pattern must be either a Regex or an AbstractString.")
     end
-    
+
     return negate ? !match_result : match_result
 end
 
@@ -278,10 +278,10 @@ end
 """
 $docstring_str_extract
 """
-function str_extract(input::AbstractString, pattern::Union{String, Regex})
+function str_extract(input::AbstractString, pattern::Union{String,Regex})
     # Convert pattern to Regex if it's a string
     regex_pattern = isa(pattern, String) ? Regex(pattern) : pattern
-    
+
     # Find the first match, return missing if none found
     m = match(regex_pattern, input)
     return m === nothing ? missing : m.match
@@ -290,14 +290,13 @@ end
 """
 $docstring_str_extract_all
 """
-function str_extract_all(string::AbstractString, pattern::Union{String, Regex})
+function str_extract_all(string::AbstractString, pattern::Union{String,Regex})
     # Convert pattern to Regex if it's a string
     regex_pattern = isa(pattern, String) ? Regex(pattern) : pattern
-    
+
     # Collect matches
     matches = [String(m.match) for m in eachmatch(regex_pattern, string)]
-    
+
     # Return missing if no matches found
     return isempty(matches) ? missing : matches
 end
-


### PR DESCRIPTION
Needed this for advent of code! This keeps the previous behaviour as the default, so it won't break any existing code, but allows a kwarg `overlap` to be set to `true`  if you want to count overlaps. 